### PR TITLE
Add HTTP2::Server::Headers_in#all

### DIFF
--- a/src/mrb_http2_server.c
+++ b/src/mrb_http2_server.c
@@ -2775,6 +2775,26 @@ static mrb_value mrb_http2_headers_in_obj(mrb_state *mrb, mrb_value self)
 {
   return mrb_http2_get_class_obj(mrb, self, "headers_in_obj", "Headers_in");
 }
+static mrb_value mrb_http2_get_reqhdrs_in_hash(mrb_state *mrb,
+		mrb_value self)
+{
+  mrb_http2_data_t *data = DATA_PTR(self);
+  mrb_http2_request_rec *r = data->r;
+  int i;
+  mrb_value hash = mrb_hash_new(mrb);
+
+  if (r->reqhdrlen <= 0) {
+    return hash;
+  }
+  for (i = 0; i < r->reqhdrlen; i++) {
+    mrb_hash_set(mrb
+      , hash
+      , mrb_str_new(mrb, (char *)r->reqhdr[i].name, r->reqhdr[i].namelen)
+      , mrb_str_new(mrb, (char *)r->reqhdr[i].value, r->reqhdr[i].valuelen)
+    );
+  }
+  return hash;
+}
 
 static mrb_value mrb_http2_get_reqhdrs(mrb_state *mrb,
     mrb_value self)
@@ -2850,6 +2870,7 @@ void mrb_http2_server_class_init(mrb_state *mrb, struct RClass *http2)
 
   hin = mrb_define_class_under(mrb, server, "Headers_in", mrb->object_class);
   mrb_define_method(mrb, hin, "[]", mrb_http2_get_reqhdrs, ARGS_ANY());
+  mrb_define_method(mrb, hin, "all", mrb_http2_get_reqhdrs_in_hash, ARGS_ANY());
 
   mrb_define_method(mrb, server, "headers_in", mrb_http2_headers_in_obj, ARGS_NONE());
   mrb_define_method(mrb, server, "request_headers", mrb_http2_headers_in_obj, ARGS_NONE());


### PR DESCRIPTION
Thanks for your advice.
I could implement it.

Now we can see what are requested in HTTP headers.

```
s.set_map_to_storage_cb {
  if s.request.uri =~ /reqhdrs/
    s.request_headers.all.each {|key,value|
      s.rputs key + " : "+ (value.to_s) + "\n"
    }
}
```

```
mruby/build/host/mrbgems/mruby-http2/nghttp2/src/nghttp http://127.0.0.1:8080/reqhdrs
accept : */*
accept-encoding : gzip, deflate
user-agent : nghttp2/0.7.5-DEV
```